### PR TITLE
Add: passing the sharding

### DIFF
--- a/scripts/quality/estimate_quality.py
+++ b/scripts/quality/estimate_quality.py
@@ -58,7 +58,8 @@ def main(_):
     tf.config.set_visible_devices([], "GPU")
 
     ds, pred_fn, dataset_ids = quality_estimators.get_dataset_and_score_fn(
-        FLAGS.estimator, FLAGS.batch_size, FLAGS.obs_ckpt, FLAGS.action_ckpt, FLAGS.obs_action_ckpt
+        FLAGS.estimator, FLAGS.batch_size, FLAGS.obs_ckpt, FLAGS.action_ckpt, FLAGS.obs_action_ckpt,
+        sharding=rep_sharding
     )
     ds = map(shard, ds)  # Apply sharding to the batches
     jitted_pred_fn = jax.jit(pred_fn, in_shardings=(dp_sharding, None), out_shardings=(rep_sharding, rep_sharding))

--- a/scripts/quality/quality_estimators.py
+++ b/scripts/quality/quality_estimators.py
@@ -151,6 +151,7 @@ def get_dataset_and_score_fn(
     action_ckpt: str | None = None,
     obs_action_ckpt: str | None = None,
     datasets: List[str] | None = None,
+    sharding: jax.sharding.Sharding | None = None,
 ):
     # First get the prediction function, and set the correct dataset parameters for it.
     if estimator == "random":
@@ -158,8 +159,8 @@ def get_dataset_and_score_fn(
         repeat, discard_fraction = 1, 0.99  # Remove almost all the data, don't repeat
     elif estimator == "ksg":
         assert obs_ckpt is not None and action_ckpt is not None
-        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt)
-        action_alg, action_state, _, _ = load_checkpoint(action_ckpt)
+        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
+        action_alg, action_state, _, _ = load_checkpoint(action_ckpt, sharding=sharding)
         pred_fn = functools.partial(
             ksg_estimator,
             ks=np.arange(5, 8),
@@ -171,8 +172,8 @@ def get_dataset_and_score_fn(
         repeat, discard_fraction = 4, 0.5
     elif estimator == "biksg":
         assert obs_ckpt is not None and action_ckpt is not None
-        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt)
-        action_alg, action_state, _, _ = load_checkpoint(action_ckpt)
+        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
+        action_alg, action_state, _, _ = load_checkpoint(action_ckpt, sharding=sharding)
         pred_fn = functools.partial(
             biksg_estimator,
             ks=np.arange(2, 5),
@@ -184,10 +185,10 @@ def get_dataset_and_score_fn(
         repeat, discard_fraction = 4, 0.5
     elif estimator == "kl":
         assert obs_ckpt is not None and action_ckpt is not None
-        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt)
-        action_alg, action_state, _, _ = load_checkpoint(action_ckpt)
+        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
+        action_alg, action_state, _, _ = load_checkpoint(action_ckpt, sharding=sharding)
         if obs_action_ckpt is not None:
-            obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt)
+            obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt, sharding=sharding)
         else:
             obs_action_alg, obs_action_state = None, None
         pred_fn = functools.partial(
@@ -204,37 +205,37 @@ def get_dataset_and_score_fn(
         repeat, discard_fraction = 4, 0.5
     elif estimator == "nce":
         assert obs_action_ckpt is not None
-        obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt)
+        obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt, sharding=sharding)
         pred_fn = functools.partial(nce_estimator, obs_action_alg=obs_action_alg, obs_action_state=obs_action_state)
         repeat, discard_fraction = 1, 0.0
     elif estimator == "vip":
         assert obs_ckpt is not None
-        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt)
+        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
         pred_fn = functools.partial(vip_estimator, obs_alg=obs_alg, obs_state=obs_state)
         repeat, discard_fraction = 1, 0.0
     elif estimator == "l2":
         assert obs_ckpt is not None
-        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt)
+        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
         pred_fn = functools.partial(l2_loss_estimator, alg=obs_alg, state=obs_state)
         repeat, discard_fraction = 1, 0.0
     elif estimator == "stddev":
         assert obs_ckpt is not None
-        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt)
+        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
         pred_fn = functools.partial(stddev_estimator, alg=obs_alg, state=obs_state)
         repeat, discard_fraction = 1, 0.0
     elif estimator == "inv_stddev":
         assert obs_ckpt is not None
-        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt)
+        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
         pred_fn = functools.partial(inverse_stddev_estimator, alg=obs_alg, state=obs_state)
         repeat, discard_fraction = 1, 0.0
     elif estimator == "compatibility":
         assert obs_ckpt is not None
-        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt)
+        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
         pred_fn = functools.partial(compatibility_estimator, alg=obs_alg, state=obs_state)
         repeat, discard_fraction = 1, 0.0
     elif estimator == "mine":
         assert obs_action_ckpt is not None
-        obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt)
+        obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt, sharding=sharding)
         pred_fn = functools.partial(mine_estimator, alg=obs_action_alg, state=obs_action_state)
         repeat, discard_fraction = 1, 0.0
     else:


### PR DESCRIPTION
https://github.com/jhejna/demonstration-information/issues/1#issuecomment-2742600838

Thank you a lot. I resolved this by following your advice.
Details are below:

- passing rep_sharding to get_dataset_and_score_fn @`demonstration-information/scripts/quality/estimate_quality.py`

```python
ds, pred_fn, dataset_ids = quality_estimators.get_dataset_and_score_fn(
        FLAGS.estimator, FLAGS.batch_size, FLAGS.obs_ckpt, FLAGS.action_ckpt, FLAGS.obs_action_ckpt,
        sharding=rep_sharding
    )
```
- passing sharding to load_checkpoint@ `demonstration-information/scripts/quality/quality_estimators.py`
```python
def get_dataset_and_score_fn(
    estimator: str,
    batch_size: int | None = None,
    obs_ckpt: str | None = None,
    action_ckpt: str | None = None,
    obs_action_ckpt: str | None = None,
    datasets: List[str] | None = None,
    sharding: jax.sharding.Sharding | None = None,
):
...
        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
        action_alg, action_state, _, _ = load_checkpoint(action_ckpt, sharding=sharding)
...
        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
        action_alg, action_state, _, _ = load_checkpoint(action_ckpt, sharding=sharding)
...
        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
        action_alg, action_state, _, _ = load_checkpoint(action_ckpt, sharding=sharding)
        if obs_action_ckpt is not None:
            obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt, sharding=sharding)
...
        obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt, sharding=sharding)
...
        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
...
        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
        pred_fn = functools.partial(l2_loss_estimator, alg=obs_alg, state=obs_state)
...
        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
...
        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
...
        obs_alg, obs_state, _, _ = load_checkpoint(obs_ckpt, sharding=sharding)
...
        obs_action_alg, obs_action_state, _, _ = load_checkpoint(obs_action_ckpt, sharding=sharding)
...
```
- change dataset path to local machine @ directory of check point`demonstration-information/output/robomimic_image/config-vip_robomimic_image_env-can_mh_seed-1/config.json`
 
```python
...
"datasets": {
            "can_mh": {
                "path": "~/demonstration-information/dataset/can/mh/robo_mimic/1.0.0",
                "train_split": "train",
                "transform": {
                    "args": [],
                    "kwargs": {},
                    "module": "openx.data.datasets.robomimic",
                    "name": "robomimic_dataset_transform"
                },
                "val_split": "val"
            }
        },
...
```